### PR TITLE
fix: parse error in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
-    GitPython~=0.3.2
+    "GitPython~=0.3.2"
 ]
 
 [build-system]


### PR DESCRIPTION
Error when installing
closes https://github.com/aerele/pwa-builder/issues/6
```
Traceback (most recent call last):
  File "apps/press/press/press/doctype/deploy_candidate/deploy_candidate.py", line 380, in _build
    self._prepare_build(no_push)
  File "apps/press/press/press/doctype/deploy_candidate/deploy_candidate.py", line 465, in _prepare_build
    self._prepare_build_context(no_push)
  File "apps/press/press/press/doctype/deploy_candidate/deploy_candidate.py", line 863, in _prepare_build_context
    repo_path_map = self._clone_repos()
  File "apps/press/press/press/doctype/deploy_candidate/deploy_candidate.py", line 897, in _clone_repos
    app.app_name = self._get_app_name(app.app)
  File "apps/press/press/press/doctype/deploy_candidate/deploy_candidate.py", line 1186, in _get_app_name
    app_name = self._get_app_pyproject(app).get("project", {}).get("name")
  File "apps/press/press/press/doctype/deploy_candidate/deploy_candidate.py", line 1214, in _get_app_pyproject
    return load_pyproject(app, pyproject_path)
  File "apps/press/press/press/doctype/deploy_candidate/utils.py", line 91, in load_pyproject
    raise Exception("App has invalid pyproject.toml file", app) from None
Exception: ('App has invalid pyproject.toml file', 'pwa_builder')
```