### PR TITLE
feat(desk): workspace for desk navigation + readme refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,50 @@
 # PWA Builder
 
-**PWA Builder** is a tool designed to help users create Progressive Web Applications (PWAs) connected to their Frappe sites. With this builder, users can connect their Frappe sites, and build app-like screens by dragging and dropping fields of their site's doctypes.
+**PWA Builder** is a low-code tool for building Progressive Web Apps on top of your Frappe site. Connect a site, drag and drop fields from your DocTypes into app screens with a live phone preview, and publish the generated Frappe app to GitHub in one click.
 
-We are improving on the addition of all the possible field types and routing abilities across screens.
+This is a project by the developers at Aerele Technologies. Feel free to reach out to us via issues.
 
-This is a hobby project by the developers at Aerele Technologies. Feel free to reach out to us via issues.
+## Features
 
-## Steps
+- **Dashboard** with a projects gallery, screen templates and a getting-started checklist.
+- **Visual builder**: three-pane editor (field palette, canvas, live phone preview) with undo/redo, validation and keyboard shortcuts.
+- **Screen templates**: start a screen from required fields, all fields or a blank canvas.
+- **Flow**: order screens into the app's navigation with drag and drop.
+- **Connections**: build for the current site (no credentials) or connect another Frappe site.
+- **One-click publish**: exports your project as a Frappe app and pushes it to your GitHub repository, with a live progress timeline.
+- **Desk workspace** for quick navigation to projects, screens and GitHub settings.
+- Dark mode, offline indicator and a desk-free UI built with frappe-ui.
 
-- Start by creating a project in the PWA Builder.
-- Connect your Frappe site to the builder and give access to your Doctypes. 
-- Select a Doctype and easily drag and drop fields from its metadata to create app screens.
-- Export your project and download a `Frappe App`.
-- Install this `Frappe App` to your actual site.
-- Access your new pwa on `https://<your-site-name>/<your-pwa-project-name>`
+## Installation
 
-![PWA Builder Screen](https://insider.frappe.cloud/files/pwa_builder.png)
+```bash
+cd $PATH_TO_YOUR_BENCH
+bench get-app https://github.com/aerele/pwa-builder.git
+bench --site <your-site> install-app pwa_builder
+bench build --app pwa_builder
+```
+
+Then open `https://<your-site>/pwa-builder` to use the builder, or open the **PWA Builder** workspace in the desk.
+
+## Usage
+
+1. Create a project: build for **this site**, or connect **another site** with its URL and credentials.
+2. Add the DocTypes you want to build screens for.
+3. Design screens in the builder: drag fields from the palette, tweak them in the inspector, and watch the live phone preview.
+4. Arrange the screen order in **Flow**.
+5. Set your GitHub username and token in **Settings**, then hit **Publish**. The generated Frappe app is pushed to your repository.
+6. Install the generated app on your site and access the PWA at `https://<your-site-name>/<your-pwa-project-name>`.
+
+## Development
+
+```bash
+cd apps/pwa_builder/frontend
+yarn install
+yarn dev        # vite dev server
+yarn build      # production build into pwa_builder/public/frontend
+```
+
+The frontend is a Vue 3 + frappe-ui SPA served at `/pwa-builder`. Built assets are not tracked in git; run `bench build --app pwa_builder` after pulling.
 
 #### License
 

--- a/pwa_builder/pwa_builder/workspace/pwa_builder/pwa_builder.json
+++ b/pwa_builder/pwa_builder/workspace/pwa_builder/pwa_builder.json
@@ -1,0 +1,99 @@
+{
+ "charts": [],
+ "content": "[{\"id\":\"pwab_head\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>PWA Builder</b></span>\",\"col\":12}},{\"id\":\"pwab_open\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Open Builder\",\"col\":3}},{\"id\":\"pwab_proj\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Projects\",\"col\":3}},{\"id\":\"pwab_scr\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Screens\",\"col\":3}},{\"id\":\"pwab_gh\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"GitHub Integration\",\"col\":3}},{\"id\":\"pwab_spacer\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"pwab_masters_head\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Masters</b></span>\",\"col\":12}},{\"id\":\"pwab_card\",\"type\":\"card\",\"data\":{\"card_name\":\"PWA Builder\",\"col\":4}}]",
+ "custom_blocks": [],
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "for_user": "",
+ "hide_custom": 0,
+ "icon": "website",
+ "idx": 0,
+ "is_hidden": 0,
+ "label": "PWA Builder",
+ "links": [
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PWA Builder",
+   "link_count": 3,
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "dependencies": "",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PWA Project",
+   "link_count": 0,
+   "link_to": "PWA-Project",
+   "link_type": "DocType",
+   "onboard": 1,
+   "type": "Link"
+  },
+  {
+   "dependencies": "",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PWA Screen",
+   "link_count": 0,
+   "link_to": "PWA DocType",
+   "link_type": "DocType",
+   "onboard": 1,
+   "type": "Link"
+  },
+  {
+   "dependencies": "",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "PWA Github Integration",
+   "link_count": 0,
+   "link_to": "PWA Github Integration",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  }
+ ],
+ "modified": "2026-07-09 12:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "PWA Builder",
+ "name": "PWA Builder",
+ "number_cards": [],
+ "owner": "Administrator",
+ "parent_page": "",
+ "public": 1,
+ "quick_lists": [],
+ "restrict_to_domain": "",
+ "roles": [],
+ "sequence_id": 99.0,
+ "shortcuts": [
+  {
+   "color": "Blue",
+   "doc_view": "List",
+   "label": "Open Builder",
+   "type": "URL",
+   "url": "/pwa-builder"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Projects",
+   "link_to": "PWA-Project",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Screens",
+   "link_to": "PWA DocType",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "GitHub Integration",
+   "link_to": "PWA Github Integration",
+   "type": "DocType"
+  }
+ ],
+ "title": "PWA Builder"
+}


### PR DESCRIPTION
Adds a PWA Builder desk workspace so the app is reachable from the desk: shortcuts to Open Builder (/pwa-builder), Projects, Screens and GitHub Integration, plus a masters card with the three doctypes. Verified on a live site (sidebar + page content resolve).

Also rewrites the README to match the redesigned product: features, install steps, usage walkthrough and a development section noting built assets are untracked.