### PR TITLE
fix: land the stranded security and build fixes on develop

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build --base=/assets/pwa_builder/frontend/ && yarn copy-html-entry",
     "preview": "vite preview",
-    "copy-html-entry": "cp ../pwa_builder/public/frontend/index.html ../pwa_builder/www/frontend.html"
+    "copy-html-entry": "mkdir -p ../pwa_builder/www && cp ../pwa_builder/public/frontend/index.html ../pwa_builder/www/frontend.html"
   },
   "dependencies": {
     "feather-icons": "^4.28.0",

--- a/pwa_builder/api.py
+++ b/pwa_builder/api.py
@@ -8,8 +8,9 @@ from frappe import ValidationError, _, qb, scrub, throw
 from pwa_builder.rename_template_app import rename_template_app
 from frappe.model.meta import Meta
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def add_site(data, update=False):
+	frappe.has_permission("PWA-Project", ptype="create", throw=True)
 	if isinstance(data, str):
 		data = json.loads(data)
 
@@ -25,7 +26,7 @@ def add_site(data, update=False):
 			"sub_title": data.get("sub_title"),
 			"site_url": frappe.utils.get_url(),
 			"description": data.get("description"),
-		}).insert(ignore_permissions=True)
+		}).insert()
 		return "Created"
 
 	url = urlparse(data.get("site_url"))
@@ -45,14 +46,13 @@ def add_site(data, update=False):
 				"user_id": data.get("user_id"),
 				"password": data.get("password"),
 				"description": data.get("description"),
-			}).insert(ignore_permissions=True)
+			}).insert()
 
 			return "Created"
 		else:
-			doc = frappe.get_doc("PW-Project", url.scheme + "://" + url.netloc)
+			doc = frappe.get_doc("PWA-Project", data.get("name"))
 
 			doc.update({
-				"doctype": "PWA-Project",
 				"project_title": data.get("project_title"),
 				"sub_title": data.get("sub_title"),
 				"site_url": data.get("site_url"),
@@ -60,14 +60,15 @@ def add_site(data, update=False):
 				"password": data.get("password"),
 				"description": data.get("description"),
 				})
-			data.save()
+			doc.save()
 			return "Updated"
 	else:
 		return "Invalid credentials"
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_meta(doctype, project,with_parent=False,cached=True) -> "Meta":
 	doc = frappe.get_doc("PWA-Project", project)
+	doc.check_permission("read")
 
 	# "This Site" — read doctype metadata locally instead of proxying over REST.
 	if (doc.connection_type or "Another Site") == "This Site":
@@ -118,19 +119,18 @@ def get_cookies(url, username, password, project,  force=False):
 			frappe.cache().hset(url, project, cookies)
 	return cookies
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def set_value(doctype, docname, fieldname, value):
-
-	 frappe.set_value(doctype, docname, fieldname, json.dumps(value, indent=4))
-
-@frappe.whitelist(allow_guest=True)
-def get_doc(doctype, docname):
-	 return frappe.get_doc(doctype, docname)
+	# only screen definitions are writable through this endpoint
+	if doctype != "PWA DocType" or fieldname != "field_list":
+		frappe.throw(_("Only field_list of PWA DocType can be updated here"), frappe.PermissionError)
+	frappe.set_value(doctype, docname, fieldname, json.dumps(value, indent=4))
 
 @frappe.whitelist()
 def export_status(project_name):
 	"""Status of the queued export job plus the project's publish fields."""
 	doc = frappe.get_doc("PWA-Project", project_name)
+	doc.check_permission("read")
 	job_status = result = None
 	try:
 		from frappe.utils.background_jobs import get_job
@@ -151,8 +151,9 @@ def export_status(project_name):
 		"last_commit": doc.last_push_commit,
 	}
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def export_project(project_name):
+	frappe.has_permission("PWA-Project", ptype="write", doc=project_name, throw=True)
 	frappe.enqueue(
 		method="pwa_builder.api.schedule_export_project",
 		project_name=project_name,
@@ -215,6 +216,7 @@ def schedule_export_project(project_name):
 # validate form mandatory fields
 @frappe.whitelist()
 def validate_form_fields(project_name):
+	frappe.has_permission("PWA-Project", ptype="read", doc=project_name, throw=True)
 	result={
 		"success":True,
 		"forms_with_missing_fields":{}

--- a/pwa_builder/pwa_builder/doctype/pwa_github_integration/pwa_github_integration.py
+++ b/pwa_builder/pwa_builder/doctype/pwa_github_integration/pwa_github_integration.py
@@ -4,6 +4,7 @@
 import os
 import git
 import json
+import base64
 import frappe
 import requests
 import shutil
@@ -18,7 +19,6 @@ class PWAGitHubIntegration(Document):
 	pass
 
 
-frappe.whitelist()
 def push_to_github(path, repo_name, current_default_branch=None, last_push_commit=None):
 	pwa_github_integration = frappe.get_single('PWA GitHub Integration')
 	github_token = pwa_github_integration.get_password('access_token')
@@ -77,7 +77,8 @@ def push_to_github(path, repo_name, current_default_branch=None, last_push_commi
 		repo = git.Repo.init(repo_path)
 		repo.git.add(A=True)
 		repo.index.commit('Initial commit')
-		correct_url = f"https://{github_token}@github.com/{repo_full_name}.git"
+		# keep the remote url credential-free; the token must never land in .git/config
+		correct_url = f"https://github.com/{repo_full_name}.git"
 
 		try:
 			origin = repo.remote(name='origin')
@@ -97,9 +98,16 @@ def push_to_github(path, repo_name, current_default_branch=None, last_push_commi
 		repo.git.add(A=True)  # Stage all files
 		repo.index.commit(commit_msg)  # Commit changes
 
-		# Force Push
+		# Force Push, authenticating via environment so the token stays out of
+		# .git/config and the git command line
+		auth = base64.b64encode(f"x-access-token:{github_token}".encode()).decode()
 		try:
-			origin.push(refspec=f'{branch_name}:{branch_name}', force=True)
+			with repo.git.custom_environment(
+				GIT_CONFIG_COUNT="1",
+				GIT_CONFIG_KEY_0="http.https://github.com/.extraheader",
+				GIT_CONFIG_VALUE_0=f"AUTHORIZATION: basic {auth}",
+			):
+				origin.push(refspec=f'{branch_name}:{branch_name}', force=True)
 			print("Force push successful.")
 		except git.exc.GitCommandError as e:
 			frappe.log_error(frappe.get_traceback(), "Git Force Push Failed")
@@ -129,9 +137,15 @@ def push_to_github(path, repo_name, current_default_branch=None, last_push_commi
 def clone_pwa_template(project_name,repo_url="https://github.com/aerele/pwa_build.git"):
     
 	project_name = scrub(project_name)
-	public_folder = os.path.join(get_site_path("public/files/"), project_name,"pwa_build")
-	project_folder = os.path.join(get_site_path("public/files/"), project_name)
+	# clone under private files: the export workdir holds a .git dir and must
+	# not be reachable over http like public/files is
+	public_folder = os.path.join(get_site_path("private", "files"), project_name,"pwa_build")
+	project_folder = os.path.join(get_site_path("private", "files"), project_name)
 	result = {'success': False, 'error': 'An error occurred.'}
+	# clean up exports left in the web-served public dir by older versions
+	legacy_folder = os.path.join(get_site_path("public", "files"), project_name)
+	if os.path.exists(legacy_folder):
+		shutil.rmtree(legacy_folder)
 	# If the directory exists and is not empty, remove it
 	if os.path.exists(project_folder) and os.listdir(project_folder):
 		shutil.rmtree(project_folder)
@@ -156,6 +170,13 @@ def clone_pwa_template(project_name,repo_url="https://github.com/aerele/pwa_buil
 		result['error'] = f"{e}"
 	return result
 
+def next_version(label):
+	# "version-3" -> "version-4"; anything unparsable restarts at version-1
+	try:
+		return f"version-{int(str(label).split('-')[-1]) + 1}"
+	except ValueError:
+		return "version-1"
+
 def get_branch_name(get_exports_on,current_default_branch):
 	branch_name=current_default_branch
 	if get_exports_on == "New Commit":
@@ -165,7 +186,7 @@ def get_branch_name(get_exports_on,current_default_branch):
 		if not current_default_branch:
 			branch_name = "version-1"
 		else:
-			branch_name = f'''version-{eval(branch_name.split("-")[-1])+1}'''
+			branch_name = next_version(branch_name)
 	return branch_name
 
 def get_commit_message(get_exports_on,last_push_commit):
@@ -174,7 +195,7 @@ def get_commit_message(get_exports_on,last_push_commit):
 		if not last_push_commit:
 			commit_msg = "version-1"
 		else:
-			commit_msg = f'''version-{eval(commit_msg.split("-")[-1])+1}'''
+			commit_msg = next_version(commit_msg)
 	elif get_exports_on == "New Branch":
 		if not last_push_commit:
 			commit_msg = "version-1"


### PR DESCRIPTION
PR #20 (api/github hardening + www build fix) was merged into pwa-builder-refactor after #19 had already carried that branch into develop, so its commits never reached develop. As a result develop still ships 5 allow_guest=True endpoints and bench build fails on the missing www/frontend.html copy.

This merges the stranded commits into develop. Clean merge, no conflicts. Verified develop now has: 0 guest endpoints and permission checks in place; the mkdir -p www build fix; the token-out-of-git-config + private export dir github fix; and the recently landed nav_order/manifest export-meta code intact. Both changed py files compile.